### PR TITLE
Add a prettier config file

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,34 @@
+useTabs: true # Indent lines with tabs instead of spaces.
+printWidth: 100 # Specify the length of line that the printer will wrap on.
+tabWidth: 2 # Specify the number of spaces per indentation-level.
+singleQuote: false # Use single quotes instead of double quotes.
+# Print trailing commas wherever possible.
+# Valid options:
+#   - "none" - no trailing commas
+#   - "es5" - trailing commas where valid in ES5 (objects, arrays, etc)
+#   - "all" - trailing commas wherever possible (function arguments)
+trailingComma: es5
+# Do not print spaces between brackets.
+# If true, puts the > of a multi-line jsx element at the end of the last line instead of being
+# alone on the next line
+jsxBracketSameLine: false
+# Print spaces between brackets in object literals
+# Valid options:
+#   - true - { foo: bar }
+#   - false - {foo: bar}
+bracketSpacing: true
+# Include parentheses around a sole arrow function parameter
+# Valid options:
+#   - "avoid" - Omit parens when possible. Example: x => x
+#   - "always" - Always include arrow parents. Example: (x) => x
+arrowParens: avoid
+# Specify which parse to use.
+# Valid options:
+#   - "flow"
+#   - "babylon"
+parser: babylon
+# Print semi colons
+# Valid options:
+#   - true - add a semicolon at the end of every line
+#   - false - only add semicolons at the beginning of lines that may introduce ASI failures
+semi: true


### PR DESCRIPTION
This is a config file for the file formatter [Prettier](https://prettier.io/). 
The options are described in the yml file. The TL;DR version is: use semicolons, use double quotes, use tabs, and a line length of 100.
It pairs nicely with [This VSCode extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) or [this Atom package](https://atom.io/packages/prettier-atom).
I figured this would be nice to have so that we can unify our style so that we don't fill up the commits with extra stuff (sorry guys).