### PR TITLE
refreshed client player state before updating

### DIFF
--- a/src/app/services/game-play-manager/game-play-manager.service.ts
+++ b/src/app/services/game-play-manager/game-play-manager.service.ts
@@ -332,6 +332,7 @@ export class GamePlayManagerService {
           if (this.updateLastCommandID(command.id)) {
             if (command.player === this.clientPlayer.name) {
               const completedRoutes = <Route[]>command.privateData.completedRoutes;
+              this.clientPlayer = this.getPlayerByName(this.clientPlayer.name);
               this.clientPlayer.routesCompleted = completedRoutes;
               this.clientPlayerSubject.next(this.clientPlayer);
             }


### PR DESCRIPTION
There was a bug where the client player's stats would reset (points and bus pieces) when they claimed their first route. It was because the client player was being updated with their route completed, which got sent to the player bar. The client player though had not been updated with points and bus pieces, just the routes. So I just updated the client player with their player in allPlayers first. It's a flaw in our design but it's the best we can do right now haha. It's working with this.